### PR TITLE
fix: filter the search result for dmzj

### DIFF
--- a/downloader/dmzj.py
+++ b/downloader/dmzj.py
@@ -19,6 +19,8 @@ class DmzjComic(ComicSource):
         for book in results:
             comic = Comic()
             comic.url = 'http:' + book['comic_url_raw']
+            if not comic.url.startswith(self.base_url):
+                continue
             comic.name = book['comic_name']
             comic.author = book['comic_author']
             arr.append(comic)


### PR DESCRIPTION
Remove the search result if comic URL starts with 'http://www.dmzj.com'