### PR TITLE
refactor: 优化图片URL处理逻辑，统一在基类中处理

### DIFF
--- a/downloader/comic.py
+++ b/downloader/comic.py
@@ -154,8 +154,11 @@ class ComicSource(ABC):
             sleep(self.download_interval)  # 保持下载间隔，避免对服务器造成过大压力
             file_path = '%s/%04d.jpg' % (path, (index + 1))
             full_img_url = ''
-            if use_uri:
-                full_img_url = self.base_img_url + '/' + img_url_part
+            if use_uri and not img_url_part.startswith('http'):
+                if img_url_part.startswith('/'):
+                    full_img_url = self.base_img_url + img_url_part
+                else:
+                    full_img_url = self.base_img_url + '/' + img_url_part
             else:
                 full_img_url = img_url_part
 

--- a/downloader/morui.py
+++ b/downloader/morui.py
@@ -214,15 +214,6 @@ class MoruiComic(ComicSource):
                 if not img_url or not isinstance(img_url, str):
                     logger.warning(f'无效的图片URL: {img_url}')
                     continue
-                # 检查URL是否完整，如果不是，则拼接
-                if not img_url.startswith('http'):
-                    # 假设图片URL是相对路径，需要根据实际情况拼接
-                    # 通常网站会将图片放在特定域名或路径下
-                    # 这里假设是相对于 base_url，但这可能不正确，需要根据实际网站结构调整
-                    # 示例：img_url = self.base_img_url.rstrip('/') + '/' + img_url.lstrip('/')
-                    # 对于thmh.com, chapterImages通常是完整URL
-                    img_url = self.base_img_url + img_url
-                    logger.debug(f"图片URL '{img_url}' 不是完整URL，将直接使用，请确认是否正确.")
                 processed_imgs.append(img_url)
                 logger.debug(f'解析到图片URL: {img_url}')
 


### PR DESCRIPTION
在 ComicSource.download_images 方法中增强 use_uri 逻辑，支持处理以斜杠开头的相对路径。同时简化 MoruiComic 中的图片URL处理，移除重复的拼接逻辑。