### PR TITLE
Fix Ctrl+C hang during download and search

### DIFF
--- a/downloader/comic.py
+++ b/downloader/comic.py
@@ -332,17 +332,24 @@ class ComicSource(ABC):
         if progress:
             task_id = progress.add_task(description=f'  [cyan]{vol_name}', total=len(imgs))
 
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
         try:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [
-                    executor.submit(download_image, (index, img_url_part))
-                    for index, img_url_part in enumerate(imgs)
-                ]
+            futures = [
+                executor.submit(download_image, (index, img_url_part))
+                for index, img_url_part in enumerate(imgs)
+            ]
 
-                for future in concurrent.futures.as_completed(futures):
-                    success, url = future.result()
-                    if progress and task_id is not None:
-                        progress.advance(task_id)
+            for future in concurrent.futures.as_completed(futures):
+                success, url = future.result()
+                if progress and task_id is not None:
+                    progress.advance(task_id)
+            executor.shutdown(wait=True)
+        except (KeyboardInterrupt, SystemExit):
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
+        except:
+            executor.shutdown(wait=True)
+            raise
         finally:
             if progress and task_id is not None:
                 progress.remove_task(task_id)

--- a/downloader/shell.py
+++ b/downloader/shell.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import cmd
 import concurrent.futures
 import importlib
@@ -95,13 +97,21 @@ def _run_search_parallel(
 
     # 并行执行后按完成顺序收集，再在外层按源顺序合并
     outcomes = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+    try:
         futures = [
             executor.submit(_execute_search_task, task, keyword, per_source_limit, driver_lock)
             for task in tasks
         ]
         for future in concurrent.futures.as_completed(futures):
             outcomes.append(future.result())
+        executor.shutdown(wait=True)
+    except (KeyboardInterrupt, SystemExit):
+        executor.shutdown(wait=False, cancel_futures=True)
+        raise
+    except:
+        executor.shutdown(wait=True)
+        raise
     return outcomes
 
 

--- a/main.py
+++ b/main.py
@@ -36,7 +36,11 @@ def main():
     else:
         output_path = args[0]
 
-    Shell(output_path, overwrite=overwrite).cmdloop()
+    shell = Shell(output_path, overwrite=overwrite)
+    try:
+        shell.cmdloop()
+    finally:
+        shell.context.destroy()
 
 
 def __handler__(signum, frame):


### PR DESCRIPTION
This PR addresses the issue where the application would hang when `Ctrl+C` was pressed during a download or search operation. The root cause was `concurrent.futures.ThreadPoolExecutor`'s context manager, which waits for all pending tasks to complete before exiting. The fix involves manually managing the executor and explicitly shutting it down with `wait=False` and `cancel_futures=True` when an interrupt signal is received. Additionally, resource cleanup in `main.py` was improved to ensure browser drivers are closed properly.

---
*PR created automatically by Jules for task [17510742620875692402](https://jules.google.com/task/17510742620875692402) started by @fjcanyue*