### PR TITLE
feat: support CLI command mode and add skill definition

### DIFF
--- a/downloader/shell.py
+++ b/downloader/shell.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import cmd
 import concurrent.futures
 import importlib

--- a/main.py
+++ b/main.py
@@ -30,13 +30,66 @@ def main():
 
     logger.add('comic_downloader.log', rotation='500 MB', level='INFO')
 
-    if len(args) == 0:
-        path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        output_path = path
-    else:
-        output_path = args[0]
+    # 检查是否包含子命令
+    subcommands = ['search', 'info', 'download', 'download_vols']
+    subcommand = None
+    subcommand_args = []
+    output_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-    Shell(output_path, overwrite=overwrite).cmdloop()
+    # 解析参数，区分 output_path 和 subcommand
+    if len(args) > 0:
+        if args[0] in subcommands:
+            subcommand = args[0]
+            subcommand_args = args[1:]
+        else:
+            output_path = args[0]
+            if len(args) > 1 and args[1] in subcommands:
+                subcommand = args[1]
+                subcommand_args = args[2:]
+
+    shell = Shell(output_path, overwrite=overwrite)
+
+    try:
+        if subcommand == 'search':
+            if not subcommand_args:
+                print("错误：请输入搜索关键字！例如: comic_downloader search 猎人")
+                sys.exit(1)
+            shell.do_s(" ".join(subcommand_args))
+        elif subcommand == 'info':
+            if not subcommand_args:
+                print("错误：请输入动漫URL地址！例如: comic_downloader info https://...")
+                sys.exit(1)
+            shell.do_i(" ".join(subcommand_args))
+        elif subcommand == 'download':
+            if not subcommand_args:
+                print("错误：请输入动漫URL地址！例如: comic_downloader download https://...")
+                sys.exit(1)
+            shell.do_d(" ".join(subcommand_args))
+        elif subcommand == 'download_vols':
+            if not subcommand_args:
+                print("错误：请输入下载范围参数！例如: comic_downloader download_vols <url> <book_index> [start_index] [end_index]")
+                sys.exit(1)
+            # URL 需要被传递进去供 info 使用
+            url = subcommand_args[0]
+            vols_args = " ".join(subcommand_args[1:])
+
+            # 首先调用 info 获取漫画对象到上下文中
+            shell.do_i(url)
+
+            if shell.context.comic is None:
+                print("获取动漫详情失败，无法下载章节。")
+                sys.exit(1)
+
+            if not vols_args:
+                print("错误：缺少章节序号！")
+                sys.exit(1)
+
+            shell.do_v(vols_args)
+        else:
+            # 交互式模式
+            shell.cmdloop()
+    finally:
+        shell.context.destroy()
 
 
 def __handler__(signum, frame):

--- a/skill.json
+++ b/skill.json
@@ -1,0 +1,78 @@
+{
+  "name": "comic_downloader",
+  "description": "一个用于搜索、查看详情和下载动漫的命令行工具",
+  "skills": [
+    {
+      "name": "search",
+      "description": "搜索动漫。根据给定的关键字从所有支持的动漫源中搜索，返回搜索结果列表（包括名称、作者、源和对应的URL）。",
+      "command_template": "comic_downloader search \"{keyword}\"",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "keyword": {
+            "type": "string",
+            "description": "要搜索的动漫关键字（例如：猎人）。"
+          }
+        },
+        "required": ["keyword"]
+      }
+    },
+    {
+      "name": "info",
+      "description": "查看动漫详情。根据动漫的URL，获取其详细信息，包括元数据以及所有的章节和话/卷列表。",
+      "command_template": "comic_downloader info {url}",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "动漫的完整URL地址。"
+          }
+        },
+        "required": ["url"]
+      }
+    },
+    {
+      "name": "download",
+      "description": "全量下载动漫。根据动漫的URL，下载该动漫的所有章节。注意此操作可能耗时较长。",
+      "command_template": "comic_downloader download {url}",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "动漫的完整URL地址。"
+          }
+        },
+        "required": ["url"]
+      }
+    },
+    {
+      "name": "download_vols",
+      "description": "按范围下载动漫章节。根据动漫URL和指定的章节序号，下载特定的一话或一系列话/卷。",
+      "command_template": "comic_downloader download_vols {url} {book_index} {start_index} {end_index}",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "动漫的完整URL地址。"
+          },
+          "book_index": {
+            "type": "integer",
+            "description": "要下载的章节（Book）序号（基于 info 命令输出的表格中的序号，从0开始）。"
+          },
+          "start_index": {
+            "type": "integer",
+            "description": "可选。要下载的话/卷（Volume）的起始序号（基于 info 命令输出的表格中的 Index）。如果只提供起始序号，将下载从该序号到章节末尾的所有话。"
+          },
+          "end_index": {
+            "type": "integer",
+            "description": "可选。要下载的话/卷（Volume）的截止序号。如果提供，将下载从起始序号到截止序号（包含）的所有话。"
+          }
+        },
+        "required": ["url", "book_index"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request expands the capabilities of the Comic Downloader CLI to support standalone execution of specific tasks, bypassing the interactive shell mode. It also introduces a `skill.json` file for integration with AI agents.

**Changes:**
1. **`main.py` enhancements:**
   - Introduced basic `sys.argv` parsing to identify specific subcommands: `search`, `info`, `download`, and `download_vols`.
   - Adapted the script to call the respective `Shell` object methods without running `cmdloop()`.
   - Included proper `try...finally` block to ensure `context.destroy()` runs on single-command executions, cleanly shutting down Selenium.
   - Retained the default behavior to launch the interactive shell if no subcommand is supplied.
2. **`downloader/shell.py` type fixes:**
   - Added `from __future__ import annotations` to resolve `TypeError` caused by evaluating `threading.Lock | None` inside type hints at runtime.
3. **`skill.json` creation:**
   - Authored a JSON file describing the four new CLI commands in a format optimized for function-calling LLMs and automated AI agents.

These changes make the tool scriptable and accessible to AI agents while maintaining backwards compatibility for interactive human users.

---
*PR created automatically by Jules for task [12430662628909833086](https://jules.google.com/task/12430662628909833086) started by @fjcanyue*